### PR TITLE
Enhance contextual date awareness in prompting scripts

### DIFF
--- a/shared-resources/prompts/universal/base-instructions.md
+++ b/shared-resources/prompts/universal/base-instructions.md
@@ -8,6 +8,8 @@ You are an expert AI assistant specializing in fantasy sports analysis, powered 
 - Include confidence assessments for all advice based on available data
 - Prioritize English-language sources for web searches and produce all responses in English
 - Always stay current with the latest sports information by conducting a web search for nearly every response unless explicitly unnecessary, prioritizing the most recent news, statistics, and data available
+- On the first response of any new chat session, you MUST perform a web search to explicitly determine and state the current date. This date will serve as the baseline for all time-sensitive information in the conversation.
+- Ensure all research, data, and recommendations are as current as possible, using the explicitly determined current date as the primary reference point for recency.
 - Maintain conversation continuity and reference previous exchanges appropriately
 
 ## Conversation Context Awareness

--- a/shared-resources/prompts/universal/web-search-guidelines.md
+++ b/shared-resources/prompts/universal/web-search-guidelines.md
@@ -45,7 +45,10 @@ Always perform a web search using the Responses API built-in tool for nearly eve
 2. **Verify assumptions** - Check if earlier analysis still holds with current information
 3. **Cross-reference findings** - Ensure consistency across multiple reliable sources
 4. **Update recommendations** - Adjust previous advice based on new information
-5. **Timestamp relevance** - Prioritize information from the last 24 hours whenever possible
+5. **Timestamp relevance** - Prioritize information from the last 24 hours relative to the *current date established at the start of the chat* whenever possible.
+
+## Date Awareness in API Submissions
+- Once the current date is determined at the beginning of a new chat (as per `base-instructions.md`), this date MUST be included at the top of every subsequent input submission to the API. For example: 'Current Date: YYYY-MM-DD. User query: ...'. This ensures continuous awareness of the established date context.
 
 ## Information Integration Best Practices
 - **Combine with conversation history** - Reference how new findings relate to previous discussion


### PR DESCRIPTION
This commit introduces changes to the universal prompting guidelines to improve my understanding and utilization of the current date.

Key changes:

- Modified `shared-resources/prompts/universal/base-instructions.md`:
    - Added instructions for me to perform a web search to determine the current date at the beginning of every new chat session with you.
    - Emphasized using this fetched date as the primary reference for ensuring all information and research are as current as possible.

- Modified `shared-resources/prompts/universal/web-search-guidelines.md`:
    - Added a guideline to include the determined current date at the top of every subsequent input I process, ensuring continuous date context.
    - Reinforced that prioritizing information from the last 24 hours should be relative to the current date established at the start of our chat.

- Reviewed sport-specific prompts (`baseball/system-prompt.md`, `basketball/system-prompt.md`, `football/system-prompt.md`) and confirmed no conflicts with these new universal guidelines.

These changes aim to ensure I consistently operate with an accurate understanding of the current date, leading to more timely and relevant advice for you, especially for time-sensitive topics like game dates and seasonal context.