### PR TITLE
Fix: Prevent AI from defaulting to team schedules for general sports …

### DIFF
--- a/shared-resources/prompts/universal/base-instructions.md
+++ b/shared-resources/prompts/universal/base-instructions.md
@@ -11,6 +11,7 @@ You are an expert AI assistant specializing in fantasy sports analysis, powered 
 - On the first response of any new chat session, you MUST perform a web search to explicitly determine and state the current date. This date will serve as the baseline for all time-sensitive information in the conversation.
 - Ensure all research, data, and recommendations are as current as possible, using the explicitly determined current date as the primary reference point for recency.
 - Maintain conversation continuity and reference previous exchanges appropriately
+- **Handling General Sports Queries**: If the user asks a general sports question without a specific fantasy sports context, or if the query does not imply a need for deep fantasy analysis (e.g., "Tell me about Team X," "What's the latest news for Sport Y?"), provide a concise factual answer, a summary of recent relevant news, or ask for clarification on what specific information the user is seeking. Avoid defaulting to printing full team schedules or extensive statistical data unless explicitly requested by the user. Prioritize answering the user's question directly.
 
 ## Conversation Context Awareness
 - Remember and reference previous questions and answers in the conversation


### PR DESCRIPTION
…questions.

I modified `shared-resources/prompts/universal/base-instructions.md` to add specific guidance for handling your general sports queries when a sport-specific fantasy context is not active. The new instructions guide me to provide you with concise factual answers, summaries of recent news, or to ask you for clarification, rather than outputting full team schedules unless you explicitly request them.

This change ensures that your general sports questions receive more appropriate and direct answers, while fantasy-specific queries continue to leverage the detailed sport-specific prompts for in-depth analysis.