### PR TITLE
Fix SSE response ID parsing in iOS client

### DIFF
--- a/ios-app/ios-app/ChatViewModel.swift
+++ b/ios-app/ios-app/ChatViewModel.swift
@@ -477,7 +477,8 @@ class ChatViewModel: ObservableObject {
             let reasoning = finalJson["reasoning"] as? String
             let confidence = finalJson["confidence_score"] as? Double
             let modelId = finalJson["model_identifier"] as? String
-            let responseId = finalJson["response_id"] as? String
+            // response_id is returned at the top level of the payload
+            let responseId = parsed["response_id"] as? String
             
             // Parse alternatives array
             var alternatives: [Alternative] = []


### PR DESCRIPTION
## Summary
- correct response_id extraction in iOS ChatViewModel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68407573e5208333825d7128946e289f