### PR TITLE
Add typewriter effect for SSE delta updates

### DIFF
--- a/ios-app/ios-app/AssistantBubble.swift
+++ b/ios-app/ios-app/AssistantBubble.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AssistantBubble: View {
     let message: ChatMessage
+    @EnvironmentObject private var viewModel: ChatViewModel
     @State private var showingDetailsOverlay = false
     @State private var showCopyConfirmation = false
     
@@ -36,7 +37,9 @@ struct AssistantBubble: View {
         VStack(alignment: .leading, spacing: 2) {
             HStack(alignment: .bottom, spacing: 8) {
                 VStack(alignment: .leading, spacing: 4) {
-                    if !message.content.isEmpty {
+                    if viewModel.streamingMessageId == message.id {
+                        streamingTextBubble()
+                    } else if !message.content.isEmpty {
                         textBubble()
                     }
                     
@@ -73,6 +76,17 @@ struct AssistantBubble: View {
                 .foregroundColor(textColor)
                 .lineSpacing(3)
                 .textSelection(.enabled)
+        }
+        .background(Color.clear)
+        .shadow(color: Color.black.opacity(0.05), radius: 2, x: 1, y: 1)
+    }
+
+    private func streamingTextBubble() -> some View {
+        BubbleShell(corners: [.topRight, .bottomRight, .topLeft]) {
+            TypewriterText(text: viewModel.streamingText)
+                .font(.system(size: 16))
+                .foregroundColor(textColor)
+                .lineSpacing(3)
         }
         .background(Color.clear)
         .shadow(color: Color.black.opacity(0.05), radius: 2, x: 1, y: 1)

--- a/ios-app/ios-app/ContentView.swift
+++ b/ios-app/ios-app/ContentView.swift
@@ -221,6 +221,7 @@ struct ContentView: View {
                     LazyVStack(spacing: 0) {
                         ForEach(viewModel.messages) { message in
                             MessageBubble(message: message)
+                                .environmentObject(viewModel)
                                 .id(message.id)
                                 .padding(.horizontal, horizontalInset)
                         }

--- a/ios-app/ios-app/MessageBubble.swift
+++ b/ios-app/ios-app/MessageBubble.swift
@@ -10,8 +10,10 @@ import SwiftUI
 // New code should use MessageRow directly
 struct MessageBubble: View {
     let message: ChatMessage
-    
+    @EnvironmentObject private var viewModel: ChatViewModel
+
     var body: some View {
         MessageRow(message: message)
+            .environmentObject(viewModel)
     }
 }

--- a/ios-app/ios-app/MessageRow.swift
+++ b/ios-app/ios-app/MessageRow.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct MessageRow: View {
     let message: ChatMessage
+    @EnvironmentObject private var viewModel: ChatViewModel
     
     var body: some View {
         if message.role == .user {
             UserBubble(message: message)
         } else {
             AssistantBubble(message: message)
+                .environmentObject(viewModel)
         }
     }
 }
@@ -28,7 +30,8 @@ struct MessageRow: View {
             content: "This is a user message",
             attachments: []
         ))
-        
+        .environmentObject(ChatViewModel())
+
         MessageRow(message: ChatMessage(
             id: UUID().uuidString,
             createdAt: Date(),
@@ -36,7 +39,8 @@ struct MessageRow: View {
             content: "This is an assistant response with some helpful advice.",
             attachments: []
         ))
+        .environmentObject(ChatViewModel())
     }
     .padding()
     .background(AppColors.backgroundColor)
-} 
+}

--- a/ios-app/ios-app/MessageRowPreview.swift
+++ b/ios-app/ios-app/MessageRowPreview.swift
@@ -17,6 +17,7 @@ import SwiftUI
             content: "This is a user message that's somewhat longer to test wrapping and bubble sizing.",
             attachments: []
         ))
+        .environmentObject(ChatViewModel())
         
         // Assistant message with structured advice
         let adviceJSON = """
@@ -49,6 +50,7 @@ import SwiftUI
             attachments: [],
             structuredAdvice: advice
         ))
+        .environmentObject(ChatViewModel())
         
         // User message with image
         if let image = UIImage(named: "Image"), let imageData = image.jpegData(compressionQuality: 0.8) {
@@ -59,6 +61,7 @@ import SwiftUI
                 content: "Check out this image",
                 attachments: [ChatMessage.Attachment(type: .image, data: imageData)]
             ))
+            .environmentObject(ChatViewModel())
         }
     }
     .padding()

--- a/ios-app/ios-app/TypewriterText.swift
+++ b/ios-app/ios-app/TypewriterText.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct TypewriterText: View {
+    let text: String
+    var typingSpeed: Double = 0.03 // seconds per character
+    @State private var displayedText: String = ""
+    @State private var currentIndex: Int = 0
+    @State private var typingTask: Task<Void, Never>? = nil
+
+    var body: some View {
+        Text(displayedText)
+            .onAppear { startTyping(for: text) }
+            .onChange(of: text) { newValue in
+                startTyping(for: newValue)
+            }
+    }
+
+    private func startTyping(for newText: String) {
+        typingTask?.cancel()
+        if newText.count < currentIndex {
+            displayedText = ""
+            currentIndex = 0
+        }
+        typingTask = Task {
+            let characters = Array(newText)
+            while currentIndex < characters.count {
+                let char = characters[currentIndex]
+                await MainActor.run { displayedText.append(char) }
+                currentIndex += 1
+                try? await Task.sleep(nanoseconds: UInt64(typingSpeed * 1_000_000_000))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `TypewriterText` view for animated text reveal
- track streaming message ID and delta text in `ChatViewModel`
- update SSE processing to update `streamingText`
- display typewriter text in `AssistantBubble` when streaming
- inject `ChatViewModel` environment object in message views

## Testing
- `xcodebuild` was unavailable so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_68408a5d583c8333821b21cc4b077fa8